### PR TITLE
Don't trim the leading v from the Electron version when it's there

### DIFF
--- a/src/dependencies.js
+++ b/src/dependencies.js
@@ -28,8 +28,9 @@ function getTrashDepends (version) {
 module.exports = {
   getElectronVersion: function getElectronVersion (options) {
     return fs.readFile(path.resolve(options.src, 'version'))
-      // The content of the version file is the tag name, e.g. "v1.8.1"
-      .then(tag => tag.toString().slice(1).trim())
+      // The content of the version file pre-4.0 is the tag name, e.g. "v1.8.1"
+      // The content of the version file post-4.0 is just the version
+      .then(tag => tag.toString().trim())
   },
   getGTKDepends: getGTKDepends,
   getTrashDepends: getTrashDepends,

--- a/test/dependencies.js
+++ b/test/dependencies.js
@@ -6,31 +6,31 @@ const dependencies = require('../src/dependencies')
 describe('dependencies', () => {
   describe('getGTKDepends', () => {
     it('returns GTK2 pre-2.0', () => {
-      chai.expect(dependencies.getGTKDepends('1.8.2')).to.equal('libgtk2.0-0')
+      chai.expect(dependencies.getGTKDepends('v1.8.2')).to.equal('libgtk2.0-0')
     })
 
     it('returns GTK3 as of 2.0', () => {
-      chai.expect(dependencies.getGTKDepends('2.0.0')).to.equal('libgtk-3-0')
+      chai.expect(dependencies.getGTKDepends('v2.0.0')).to.equal('libgtk-3-0')
     })
   })
 
   describe('getTrashDepends', () => {
     it('only depends on gvfs-bin before 1.4.1', () => {
-      const trashDepends = dependencies.getTrashDepends('1.3.0')
+      const trashDepends = dependencies.getTrashDepends('v1.3.0')
       chai.expect(trashDepends).to.match(/gvfs-bin/)
       chai.expect(trashDepends).to.not.match(/kde-cli-tools/)
       chai.expect(trashDepends).to.not.match(/libglib2\.0-bin/)
     })
 
     it('depends on KDE tools between 1.4.1 and 1.7.1', () => {
-      const trashDepends = dependencies.getTrashDepends('1.6.0')
+      const trashDepends = dependencies.getTrashDepends('v1.6.0')
       chai.expect(trashDepends).to.match(/gvfs-bin/)
       chai.expect(trashDepends).to.match(/kde-cli-tools/)
       chai.expect(trashDepends).to.not.match(/libglib2\.0-bin/)
     })
 
     it('depends on glib starting with 1.7.2', () => {
-      const trashDepends = dependencies.getTrashDepends('1.8.2')
+      const trashDepends = dependencies.getTrashDepends('v1.8.2')
       chai.expect(trashDepends).to.match(/gvfs-bin/)
       chai.expect(trashDepends).to.match(/kde-cli-tools/)
       chai.expect(trashDepends).to.match(/libglib2\.0-bin/)


### PR DESCRIPTION
I didn't realize that a leading `v` was acceptable to pass into `semver` when I initially wrote this feature.

Fixes #152.