### PR TITLE
Change requirement to Node 6 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ## Requirements
 
-This tool requires Node 4 or greater, `fakeroot`, and `dpkg` to build the `.deb` package.
+This tool requires Node 6 or greater, `fakeroot`, and `dpkg` to build the `.deb` package.
 
 I'd recommend building your packages on your target platform, but if you insist on using Mac OS X, you can install these tools through [Homebrew](http://brew.sh/):
 


### PR DESCRIPTION
It seems that we didn't change this when we dropped support for node 4