### PR TITLE
Move common functionality to electron-installer-common

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,16 +33,13 @@
     "node": ">=6.0.0"
   },
   "dependencies": {
-    "asar": "^0.14.0",
-    "cross-spawn-promise": "^0.10.1",
     "debug": "^4.0.1",
+    "electron-installer-common": "^0.1.0",
     "fs-extra": "^7.0.0",
     "get-folder-size": "^2.0.0",
-    "glob": "^7.1.2",
     "lodash": "^4.17.4",
     "pify": "^4.0.0",
     "semver": "^5.4.1",
-    "temp": "^0.8.3",
     "word-wrap": "^1.2.3",
     "yargs": "^12.0.2"
   },
@@ -57,6 +54,7 @@
     "mocha": "^5.0.5",
     "mz": "^2.7.0",
     "nyc": "^13.0.1",
-    "promise-retry": "^1.1.1"
+    "promise-retry": "^1.1.1",
+    "temp": "^0.8.3"
   }
 }

--- a/src/installer.js
+++ b/src/installer.js
@@ -1,14 +1,12 @@
 'use strict'
 
 const _ = require('lodash')
-const asar = require('asar')
+const common = require('electron-installer-common')
 const debug = require('debug')
 const fs = require('fs-extra')
 const fsize = require('get-folder-size')
-const glob = require('glob')
 const path = require('path')
 const pify = require('pify')
-const temp = require('temp').track()
 const wrap = require('word-wrap')
 
 const dependencies = require('./dependencies')
@@ -18,47 +16,6 @@ const defaultLogger = debug('electron-installer-debian')
 
 const defaultRename = (dest, src) => {
   return path.join(dest, '<%= name %>_<%= version %>_<%= arch %>.deb')
-}
-
-function errorMessage (message, err) {
-  return `Error ${message}: ${err.message || err}`
-}
-
-function wrapError (message) {
-  return err => {
-    /* istanbul ignore next */
-    throw new Error(errorMessage(message, err))
-  }
-}
-
-/**
- * Read `package.json` either from `resources/app.asar` (if the app is packaged)
- * or from `resources/app/package.json` (if it is not).
- */
-function readMeta (options) {
-  const appAsarPath = path.join(options.src, 'resources/app.asar')
-  const appPackageJSONPath = path.join(options.src, 'resources/app/package.json')
-
-  return fs.pathExists(appAsarPath)
-    .then(asarExists => {
-      if (asarExists) {
-        options.logger(`Reading package metadata from ${appAsarPath}`)
-        return JSON.parse(asar.extractFile(appAsarPath, 'package.json'))
-      } else {
-        options.logger(`Reading package metadata from ${appPackageJSONPath}`)
-        return fs.readJson(appPackageJSONPath)
-      }
-    }).catch(wrapError('reading package metadata'))
-}
-
-/**
- * Read `LICENSE` from the root of the app.
- */
-function copyLicense (options, copyrightFile) {
-  const licenseSrc = path.join(options.src, 'LICENSE')
-  options.logger(`Copying license file from ${licenseSrc}`)
-
-  return fs.copy(licenseSrc, copyrightFile)
 }
 
 /**
@@ -84,24 +41,17 @@ function transformVersion (version) {
  */
 function getDefaults (data) {
   const src = { src: data.src }
-  return Promise.all([readMeta(data), getSize(src), dependencies.getElectronVersion(src)])
+  return Promise.all([common.readMeta(data), getSize(src), dependencies.getElectronVersion(src)])
     .then(results => {
       const pkg = results[0] || {}
       const size = results[1] || 0
       const electronVersion = results[2]
 
-      return {
-        name: pkg.name || 'electron',
-        productName: pkg.productName || pkg.name,
-        genericName: pkg.genericName || pkg.productName || pkg.name,
-        description: pkg.description,
-        productDescription: pkg.productDescription || pkg.description,
+      return Object.assign(common.getDefaultsFromPackageJSON(pkg), {
         version: transformVersion(pkg.version || '0.0.0'),
-        revision: pkg.revision || '1',
 
         section: 'utils',
         priority: 'optional',
-        arch: undefined,
         size: Math.ceil(size / 1024),
 
         depends: dependencies.getDepends(electronVersion),
@@ -124,24 +74,9 @@ function getDefaults (data) {
           (pkg.author.email != null ? ` <${pkg.author.email}>` : '')
         ),
 
-        homepage: pkg.homepage || (pkg.author && (typeof pkg.author === 'string'
-          ? pkg.author.replace(/.*\(([^)]+)\).*/, '$1')
-          : pkg.author.url
-        )),
-
-        bin: pkg.name || 'electron',
         icon: path.resolve(__dirname, '../resources/icon.png'),
-
-        categories: [
-          'GNOME',
-          'GTK',
-          'Utility'
-        ],
-
-        mimeType: [],
-
         lintianOverrides: []
-      }
+      })
     })
 }
 
@@ -187,20 +122,6 @@ function getOptions (data, defaults) {
 }
 
 /**
- * Fill in a template with the hash of options.
- */
-function generateTemplate (options, file) {
-  options.logger(`Generating template from ${file}`)
-
-  return fs.readFile(file)
-    .then(template => {
-      const result = _.template(template)(options)
-      options.logger(`Generated template from ${file}\n${result}`)
-      return result
-    })
-}
-
-/**
  * Create the control file for the package.
  *
  * See: https://www.debian.org/doc/debian-policy/ch-controlfields.html
@@ -211,9 +132,9 @@ function createControl (options, dir) {
   options.logger(`Creating control file at ${controlDest}`)
 
   return fs.ensureDir(path.dirname(controlDest), '0755')
-    .then(() => generateTemplate(options, controlSrc))
+    .then(() => common.generateTemplate(options, controlSrc))
     .then(data => fs.outputFile(controlDest, data))
-    .catch(wrapError('creating control file'))
+    .catch(common.wrapError('creating control file'))
 }
 
 /**
@@ -231,94 +152,12 @@ function copyScripts (options, dir) {
     } else {
       throw new Error(`Wrong executable script name: ${key}`)
     }
-  })).catch(wrapError('creating script files'))
+  })).catch(common.wrapError('creating script files'))
 }
 
-/**
- * Create the binary for the package.
- */
-function createBinary (options, dir) {
-  const binDir = path.join(dir, 'usr/bin')
-  const binSrc = path.join('../lib', options.name, options.bin)
-  const binDest = path.join(binDir, options.name)
-  options.logger(`Symlinking binary from ${binSrc} to ${binDest}`)
-
-  return fs.ensureDir(binDir, '0755')
-    .catch(wrapError('creating binary path'))
-    .then(() => fs.symlink(binSrc, binDest, 'file'))
-    .catch(wrapError('creating binary file'))
-}
-
-/**
- * Create the desktop file for the package.
- *
- * See: http://standards.freedesktop.org/desktop-entry-spec/latest/
- */
 function createDesktop (options, dir) {
   const desktopSrc = options.desktopTemplate || path.resolve(__dirname, '../resources/desktop.ejs')
-  const desktopDest = path.join(dir, 'usr/share/applications', `${options.name}.desktop`)
-  options.logger(`Creating desktop file at ${desktopDest}`)
-
-  return fs.ensureDir(path.dirname(desktopDest), '0755')
-    .catch(wrapError('creating desktop path'))
-    .then(() => generateTemplate(options, desktopSrc))
-    .then(data => fs.outputFile(desktopDest, data))
-    .then(() => fs.chmod(desktopDest, '0644'))
-    .catch(wrapError('creating desktop file'))
-}
-
-/**
- * Create pixmap icon for the package.
- */
-function createPixmapIcon (options, dir) {
-  const iconFile = path.join(dir, 'usr/share/pixmaps', `${options.name}.png`)
-  options.logger(`Creating icon file at ${iconFile}`)
-
-  return fs.ensureDir(path.dirname(iconFile), '0755')
-    .catch(wrapError('creating icon path'))
-    .then(() => fs.copy(options.icon, iconFile))
-    .then(() => fs.chmod(iconFile, '0644'))
-    .catch(wrapError('creating icon file'))
-}
-
-/**
- * Create hicolor icon for the package.
- */
-function createHicolorIcon (options, dir) {
-  return Promise.all(_.map(options.icon, (icon, resolution) => {
-    const iconExt = resolution === 'scalable' ? 'svg' : 'png'
-    const iconFile = path.join(dir, 'usr/share/icons/hicolor', resolution, 'apps', `${options.name}.${iconExt}`)
-    options.logger(`Creating icon file at ${iconFile}`)
-
-    return fs.ensureDir(path.dirname(iconFile), '0755')
-      .then(() => fs.copy(icon, iconFile))
-      .then(() => fs.chmod(iconFile, '0644'))
-      .catch(wrapError('creating icon file'))
-  }))
-}
-
-/**
- * Create icon for the package.
- */
-function createIcon (options, dir) {
-  if (_.isObject(options.icon)) {
-    return createHicolorIcon(options, dir)
-  } else {
-    return createPixmapIcon(options, dir)
-  }
-}
-
-/**
- * Create copyright for the package.
- */
-function createCopyright (options, dir) {
-  const copyrightFile = path.join(dir, 'usr/share/doc', options.name, 'copyright')
-  options.logger(`Creating copyright file at ${copyrightFile}`)
-
-  return fs.ensureDir(path.dirname(copyrightFile), '0755')
-    .then(() => copyLicense(options, copyrightFile))
-    .then(() => fs.chmod(copyrightFile, '0644'))
-    .catch(wrapError('creating copyright file'))
+  return common.createDesktop(options, dir, desktopSrc)
 }
 
 /**
@@ -330,59 +169,33 @@ function createOverrides (options, dir) {
   options.logger(`Creating lintian overrides at ${overridesDest}`)
 
   return fs.ensureDir(path.dirname(overridesDest), '0755')
-    .then(() => generateTemplate(options, overridesSrc))
+    .then(() => common.generateTemplate(options, overridesSrc))
     .then(data => fs.outputFile(overridesDest, data))
     .then(() => fs.chmod(overridesDest, '0644'))
-    .catch(wrapError('creating lintian overrides file'))
+    .catch(common.wrapError('creating lintian overrides file'))
 }
 
 /**
  * Copy the application into the package.
  */
 function createApplication (options, dir) {
-  const applicationDir = path.join(dir, 'usr/lib', options.name)
-  const licenseFile = path.join(applicationDir, 'LICENSE')
-  options.logger(`Copying application to ${applicationDir}`)
-
-  return fs.ensureDir(applicationDir, '0755')
-    .then(() => fs.copy(options.src, applicationDir))
-    .then(() => fs.unlink(licenseFile))
-    .catch(wrapError('copying application directory'))
-}
-
-/**
- * Create temporary directory where the contents of the package will live.
- */
-function createDir (options) {
-  options.logger('Creating temporary directory')
-  let tempDir
-
-  return pify(temp.mkdir)('electron-')
-    .then(dir => {
-      tempDir = path.join(dir, `${options.name}_${options.version}_${options.arch}`)
-      return fs.ensureDir(tempDir, '0755')
-    })
-    .catch(wrapError('creating temporary directory'))
+  return common.copyApplication(options, dir, null, src => src !== path.join(options.src, 'LICENSE'))
 }
 
 /**
  * Create the contents of the package.
  */
 function createContents (options, dir) {
-  options.logger('Creating contents of package')
-  options.logger(`createContents(${options}, ${dir})`)
-
-  return Promise.all([
+  return common.createContents(options, dir, [
     createControl,
     copyScripts,
-    createBinary,
+    common.createBinary,
     createDesktop,
-    createIcon,
-    createCopyright,
+    common.createIcon,
+    common.createCopyright,
     createOverrides,
     createApplication
-  ].map(func => func(options, dir)))
-    .then(() => dir)
+  ])
 }
 
 /**
@@ -402,16 +215,8 @@ function createPackage (options, dir) {
  * Move the package to the specified destination.
  */
 function movePackage (options, dir) {
-  options.logger('Moving package to destination')
-
   const packagePattern = path.join(dir, '../*.deb')
-  return pify(glob)(packagePattern)
-    .then(files => Promise.all(files.map(file => {
-      const template = options.rename(options.dest, path.basename(file))
-      const dest = _.template(template)(options)
-      options.logger(`Moving file ${file} to ${dest}`)
-      return fs.move(file, dest, { clobber: true })
-    }))).catch(wrapError('moving package files'))
+  return common.movePackage(packagePattern, options, dir)
 }
 
 /* ************************************************************************** */
@@ -431,7 +236,7 @@ module.exports = data => {
     .then(generatedOptions => {
       options = generatedOptions
       return data.logger(`Creating package with options\n${JSON.stringify(options, null, 2)}`)
-    }).then(() => createDir(options))
+    }).then(() => common.createDir(options))
     .then(dir => createContents(options, dir))
     .then(dir => createPackage(options, dir))
     .then(dir => movePackage(options, dir))
@@ -439,7 +244,7 @@ module.exports = data => {
       data.logger(`Successfully created package at ${options.dest}`)
       return options
     }).catch(err => {
-      data.logger(errorMessage('creating package', err))
+      data.logger(common.errorMessage('creating package', err))
       throw err
     })
 }

--- a/src/spawn.js
+++ b/src/spawn.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const spawn = require('cross-spawn-promise')
+const { spawn } = require('electron-installer-common')
 
 function updateExecutableMissingException (err, updateError) {
   if (updateError && err.code === 'ENOENT') {
@@ -16,18 +16,6 @@ function updateExecutableMissingException (err, updateError) {
   }
 }
 
-/**
- * Spawn a child process and make the error message more human friendly, if possible.
- */
 module.exports = function (cmd, args, logger) {
-  if (logger) logger(`Executing command ${cmd} ${args.join(' ')}`)
-
-  return spawn(cmd, args)
-    .then(stdout => stdout.toString())
-    .catch(err => {
-      const stderr = err.stderr ? err.stderr.toString() : ''
-      updateExecutableMissingException(err, !!logger)
-
-      throw new Error(`Error executing command (${err.message || err}):\n${cmd} ${args.join(' ')}\n${stderr}`)
-    })
+  return spawn(cmd, args, logger, updateExecutableMissingException)
 }

--- a/test/installer.js
+++ b/test/installer.js
@@ -130,6 +130,29 @@ describe('module', function () {
         })
   )
 
+  describeInstaller(
+    'move LICENSE to Debian-specific location',
+    {
+      src: 'test/fixtures/app-without-asar/'
+    },
+    'moves the LICENSE file to the appropriate location',
+    outputDir =>
+      assertNonASARDebExists(outputDir)
+        .then(() => exec('dpkg-deb -x bartest_amd64.deb .', { cwd: outputDir }))
+        .then(() => fs.pathExists(path.join(outputDir, 'usr/lib/bartest/LICENSE')))
+        .then(exists => {
+          if (exists) {
+            throw new Error('LICENSE was copied over erronenously')
+          }
+          return fs.pathExists(path.join(outputDir, 'usr/share/doc/bartest/copyright'))
+        }).then(exists => {
+          if (!exists) {
+            throw new Error('copyright file does not exist')
+          }
+          return Promise.resolve()
+        })
+  )
+
   describe('with no description or productDescription provided', test => {
     const outputDir = tempOutputDir()
     cleanupOutputDir(outputDir)

--- a/test/spawn.js
+++ b/test/spawn.js
@@ -11,12 +11,6 @@ describe('spawn', () => {
     process.env.PATH = '/non-existent-path'
   })
 
-  it('should throw an error when it cannot find an executable', () => {
-    return spawn('does-not-exist', [])
-      .then(() => { throw new Error('does-not-exist should not have existed') })
-      .catch(error => chai.expect(error.message).to.match(/Error executing command/))
-  })
-
   it('should throw a human-friendly error when it cannot find dpkg or fakeroot', () => {
     return spawn('dpkg', ['--version'], msg => {})
       .then(() => { throw new Error('dpkg should not have been executed') })


### PR DESCRIPTION
As promised, a pull request to move common code to [its own module](https://github.com/electron-userland/electron-installer-common).