### PR TITLE
添加iconName选项

### DIFF
--- a/resources/desktop.ejs
+++ b/resources/desktop.ejs
@@ -3,7 +3,8 @@
 <% } %><% if (description) { %>Comment=<%= description %>
 <% } %><% if (genericName) { %>GenericName=<%= genericName %>
 <% } %><% if (name) { %>Exec=<%= name %> %U
-<% } %><% if (name) { %>Icon=<%= name %>
+<% } %><% if (name && !iconName ) { %>Icon=<%= name %>
+<% } %><% if (iconName) { %>Icon=<%= iconName %>
 <% } %>Type=Application
 StartupNotify=true
 <% if (categories && categories.length) { %>Categories=<%= categories.join(';') %>;

--- a/src/installer.js
+++ b/src/installer.js
@@ -264,7 +264,10 @@ function createDesktop (options, dir) {
  * Create pixmap icon for the package.
  */
 function createPixmapIcon (options, dir) {
-  const iconFile = path.join(dir, 'usr/share/pixmaps', `${options.name}.png`)
+
+  let iconName = options.iconName || options.name;
+
+  const iconFile = path.join(dir, 'usr/share/pixmaps', `${iconName}.png`)
   options.logger(`Creating icon file at ${iconFile}`)
 
   return pify(mkdirp)(path.dirname(iconFile), '0755')
@@ -279,8 +282,11 @@ function createPixmapIcon (options, dir) {
  */
 function createHicolorIcon (options, dir) {
   return Promise.all(_.map(options.icon, (icon, resolution) => {
+
+    const iconName = options.iconName || options.name;
+
     const iconExt = resolution === 'scalable' ? 'svg' : 'png'
-    const iconFile = path.join(dir, 'usr/share/icons/hicolor', resolution, 'apps', `${options.name}.${iconExt}`)
+    const iconFile = path.join(dir, 'usr/share/icons/hicolor', resolution, 'apps', `${iconName}.${iconExt}`)
     options.logger(`Creating icon file at ${iconFile}`)
 
     return pify(mkdirp)(path.dirname(iconFile), '0755')


### PR DESCRIPTION
解决部分操作系统下图标名称冲突导致无法正常显示图标问题（deepin下vscode存在该问题）