### PR TITLE
Remove unnecessary if from desktop file template

### DIFF
--- a/resources/desktop.ejs
+++ b/resources/desktop.ejs
@@ -3,7 +3,7 @@
 <% } %><% if (description) { %>Comment=<%= description %>
 <% } %><% if (genericName) { %>GenericName=<%= genericName %>
 <% } %><% if (name) { %>Exec=<%= name %> %U
-<% } %><% if (name) { %>Icon=<%= name %>
+Icon=<%= name %>
 <% } %>Type=Application
 StartupNotify=true
 <% if (categories && categories.length) { %>Categories=<%= categories.join(';') %>;


### PR DESCRIPTION
The second `if name` was redundant.