### PR TITLE
Release 1.1.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,15 @@
 
 ## [Unreleased]
 
-[Unreleased]: https://github.com/electron-userland/electron-installer-debian/compare/v1.1.0...master
+[Unreleased]: https://github.com/electron-userland/electron-installer-debian/compare/v1.1.1...master
+
+## [1.1.1] - 2019-02-20
+
+[1.1.1]: https://github.com/electron-userland/electron-installer-debian/compare/v1.1.0...v1.1.1
+
+### Changed
+
+* Upgrade to `electron-installer-common@^0.6.1` (#174)
 
 ## [1.1.0] - 2019-01-06
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "debug": "^4.1.1",
-    "electron-installer-common": "^0.6.0",
+    "electron-installer-common": "^0.6.1",
     "fs-extra": "^7.0.1",
     "get-folder-size": "^2.0.1",
     "lodash": "^4.17.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "electron-installer-debian",
   "description": "Create a Debian package for your Electron app.",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "author": {
     "name": "Daniel Perez Alvarez",


### PR DESCRIPTION
Also upgrades `electron-installer-common` to `^0.6.1` to pick up the `asar` version bump.

@fcastilloec I am expediting this release due to the security vulnerability in `asar`.