### PR TITLE
fix(dependencies): add support for newer gconf library name

### DIFF
--- a/src/dependencies.js
+++ b/src/dependencies.js
@@ -3,7 +3,7 @@
 const common = require('electron-installer-common')
 
 const dependencyMap = {
-  gconf: 'libgconf2-4',
+  gconf: 'libgconf-2-4 | libgconf2-4',
   glib2: 'libglib2.0-bin',
   gtk2: 'libgtk2.0-0',
   gtk3: 'libgtk-3-0',


### PR DESCRIPTION
See:
* https://packages.ubuntu.com/search?keywords=libgconf-2-4
* https://github.com/electron-userland/electron-installer-debian/issues/141#issuecomment-466611638