### PR TITLE
Release 1.2.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,19 @@
 
 ## [Unreleased]
 
-[Unreleased]: https://github.com/electron-userland/electron-installer-debian/compare/v1.1.1...master
+[Unreleased]: https://github.com/electron-userland/electron-installer-debian/compare/v1.2.0...master
+
+## [1.2.0] - 2019-05-01
+
+[1.2.0]: https://github.com/electron-userland/electron-installer-debian/compare/v1.1.1...v1.2.0
+
+### Added
+
+* Support for SUID sandbox helper in Electron >= 5 (#184)
+
+### Fixed
+
+* Allow GConf dependency with non-deprecated package name (#185)
 
 ## [1.1.1] - 2019-02-20
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "electron-installer-debian",
   "description": "Create a Debian package for your Electron app.",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "license": "MIT",
   "author": {
     "name": "Daniel Perez Alvarez",


### PR DESCRIPTION
This is (likely) the last 1.x release before 2.0, which will address the revision issue plus upgrade to Node 8 (and async/await syntax).