### PR TITLE
fix: ensure control directory has right permissions

### DIFF
--- a/src/installer.js
+++ b/src/installer.js
@@ -92,11 +92,10 @@ class DebianInstaller extends common.ElectronInstaller {
     this.options.logger(`Creating control file at ${dest}`)
 
     return common.wrapError('creating control file', async () => {
+      await this.createTemplatedFile(src, dest)
 
-      await this.createTemplatedFile(src, dest);
-
-      const contrlDir = path.join(this.stagingDir, 'DEBIAN');
-      return fs.chmod(contrlDir, 0o755);
+      const controlDir = path.join(this.stagingDir, 'DEBIAN')
+      return fs.chmod(controlDir, 0o755)
     })
   }
 

--- a/src/installer.js
+++ b/src/installer.js
@@ -91,7 +91,13 @@ class DebianInstaller extends common.ElectronInstaller {
     const dest = path.join(this.stagingDir, 'DEBIAN', 'control')
     this.options.logger(`Creating control file at ${dest}`)
 
-    return common.wrapError('creating control file', async () => this.createTemplatedFile(src, dest))
+    return common.wrapError('creating control file', async () => {
+
+      await this.createTemplatedFile(src, dest);
+
+      const contrlDir = path.join(this.stagingDir, 'DEBIAN');
+      return fs.chmod(contrlDir, 0o755);
+    })
   }
 
   /**


### PR DESCRIPTION
This PR aims to fix the error: 
```
dpkg-deb: error: control directory has bad permissions 777 (must be >=0755 and <=0775)
Error: Command failed with a non-zero return code (2):
...
```
Related issues: 
1. [Temporary build directory created with insufficient permissions ](https://github.com/electron-userland/electron-installer-debian/issues/133#issue-302442035)
2. [Set permissions on scripts after copying](https://github.com/electron-userland/electron-installer-debian/issues/207)