### PR TITLE
Change in electron-packager command

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Say your Electron app lives in `path/to/app`, and has a structure like this:
 You now run `electron-packager` to build the app for Debian:
 
 ```
-$ electron-packager . app --platform linux --arch x64 --out dist/
+$ npx electron-packager . app --platform linux --arch x64 --out dist/
 ```
 
 And you end up with something like this in your `dist` folder:


### PR DESCRIPTION
Included npx in the start of electron-packager command  like "npx electron-packager . app --platform linux --arch x64 --out dist/" to resolve the issue "electron-packager: command not found" in ubuntu