### PR TITLE
Allow overriding StartupWMClass in .desktop file

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,12 @@ Default: `package.productDescription || package.description`
 
 Long description of the application, used in the [`Description` field of the `control` specification](https://www.debian.org/doc/debian-policy/#the-extended-description).
 
+#### options.startupWmClass
+Type: `String`
+Default: `undefined`
+
+Value of the [`StartupWMClass` field of the `desktop` specification](http://standards.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html).
+
 #### options.version
 Type: `String`
 Default: `package.version || "0.0.0"`

--- a/resources/desktop.ejs
+++ b/resources/desktop.ejs
@@ -6,6 +6,7 @@
 Icon=<%= name %>
 <% } %>Type=Application
 StartupNotify=true
-<% if (categories && categories.length) { %>Categories=<%= categories.join(';') %>;
+<% if (startupWmClass) { %>StartupWMClass=<%= startupWmClass %>
+<% } %><% if (categories && categories.length) { %>Categories=<%= categories.join(';') %>;
 <% } %><% if (mimeType && mimeType.length) { %>MimeType=<%= mimeType.join(';') %>;
 <% } %>


### PR DESCRIPTION
This flag can be relevant for window grouping in app launchers (e.g.
Unity on Ubuntu). It should be set to the `WM_CLASS` attribute as
returned by the `xprop` utility.

If this is not set, it's possible that the window will not be recognized
as part of the application. If that happens, if you click on a shortcut
icon on the launcher, a second icon will pop up, instead of a dot
appearing on top of the shortcut icon.