### PR TITLE
Compression Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Even though you can pass most of these options through the command-line interfac
 {
   "dest": "dist/installers/",
   "icon": "resources/Icon.png",
+  "compression": "gzip",
   "categories": [
     "Utility"
   ],
@@ -326,7 +327,7 @@ Type: `String`
 Default: `package.homepage || package.author.url`
 
 URL of the homepage for the package, used in the [`Homepage` field of the `control` specification](https://www.debian.org/doc/debian-policy/#homepage).
-
+on error value, default is: `'xz'`
 #### options.bin
 Type: `String`
 Default: `package.name || "electron"`
@@ -429,6 +430,13 @@ Default: [`resources/desktop.ejs`](https://github.com/electron-userland/electron
 
 The absolute path to a custom template for the generated [FreeDesktop.org desktop
 entry](http://standards.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html) file.
+
+#### options.compression
+Type: `String`
+Default: `undefined`
+
+Set the compression type used by dpkg-deb when building .deb package
+Allowed values: `'xz', 'gzip', 'bzip2', 'lzma', 'zstd', 'none'`
 
 ### Installed Package
 

--- a/src/installer.js
+++ b/src/installer.js
@@ -112,6 +112,11 @@ class DebianInstaller extends common.ElectronInstaller {
     this.options.logger(`Creating package at ${this.stagingDir}`)
 
     const command = ['--build', this.stagingDir]
+
+    if(this.options.compression) {
+       command.unshift(`-Z${this.options.compression}`)
+    }
+
     if (process.platform === 'darwin') {
       command.unshift('--root-owner-group')
     }
@@ -141,6 +146,8 @@ class DebianInstaller extends common.ElectronInstaller {
 
       maintainer: this.getMaintainer(pkg.author),
 
+      compression: undefined,
+
       icon: path.resolve(__dirname, '../resources/icon.png'),
       lintianOverrides: []
     }, debianDependencies.forElectron(electronVersion))
@@ -166,6 +173,12 @@ class DebianInstaller extends common.ElectronInstaller {
 
     if (this.options.productDescription) {
       this.options.productDescription = this.normalizeExtendedDescription(this.options.productDescription)
+    }
+
+    // options.compression validation
+    const compressionTypes = ['xz', 'gzip', 'bzip2', 'lzma', 'zstd', 'none']
+    if (this.options.compression && !compressionTypes.includes(this.options.compression)) {
+      throw new Error("Compression option should be one of these values: xz, gzip, bzip2, lzma, zstd or none. Please, verify it")
     }
 
     // Create array with unique values from default & user-supplied dependencies


### PR DESCRIPTION
Resolves https://github.com/electron-userland/electron-installer-debian/issues/272

Added in config.json file sent as a parameter in the generation of .deb packages (--config={file json}) allowing the possibility to define the type of compression to use.

For example:
` { "compression": "gzip" }`

Type: String
Default: undefined

Allowed values: 'xz', 'gzip', 'bzip2', 'lzma', 'zstd', 'none'
If option exists in json file but none of these values are set, it throws an error
if option is undefined (default), it runs with the default value of dpkg-deb installed on the O.S.