### PR TITLE
feat: allow setting custom compression options

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Even though you can pass most of these options through the command-line interfac
 {
   "dest": "dist/installers/",
   "icon": "resources/Icon.png",
+  "compression": "gzip",
   "categories": [
     "Utility"
   ],
@@ -429,6 +430,15 @@ Default: [`resources/desktop.ejs`](https://github.com/electron-userland/electron
 
 The absolute path to a custom template for the generated [FreeDesktop.org desktop
 entry](http://standards.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html) file.
+
+#### options.compression
+Type: `String`
+Default: `xz`
+
+Set the compression type used by dpkg-deb when building .deb package
+Allowed values: `'xz', 'gzip', 'bzip2', 'lzma', 'zstd', 'none'`
+
+Used by `dpkg-deb` to set the compression type. You can read more about it on the [manual page of `dpkg-deb`](https://man7.org/linux/man-pages/man1/dpkg-deb.1.html)
 
 ### Installed Package
 

--- a/src/installer.js
+++ b/src/installer.js
@@ -115,6 +115,11 @@ class DebianInstaller extends common.ElectronInstaller {
     if (process.platform === 'darwin') {
       command.unshift('--root-owner-group')
     }
+
+    if (this.options.compression) {
+      command.unshift(`-Z${this.options.compression}`)
+    }
+
     command.unshift('dpkg-deb')
 
     const output = await spawn('fakeroot', command, this.options.logger)
@@ -166,6 +171,11 @@ class DebianInstaller extends common.ElectronInstaller {
 
     if (this.options.productDescription) {
       this.options.productDescription = this.normalizeExtendedDescription(this.options.productDescription)
+    }
+
+    const compressionTypes = ['xz', 'gzip', 'bzip2', 'lzma', 'zstd', 'none']
+    if (this.options.compression && !compressionTypes.includes(this.options.compression)) {
+      throw new Error('Invalid compression type. xz, gzip, bzip2, lzma, zstd, or none are supported.')
     }
 
     // Create array with unique values from default & user-supplied dependencies

--- a/test/installer.js
+++ b/test/installer.js
@@ -251,4 +251,33 @@ describe('module', function () {
       chai.expect(installer.transformVersion('1.2.3-beta.4')).to.equal('1.2.3~beta.4')
     })
   })
+
+  describeInstaller(
+    'with different compression type',
+    {
+      src: 'test/fixtures/app-with-asar/',
+      options: {
+        arch: 'i386',
+        compression: 'gzip'
+      }
+    },
+    'generates a .deb package with gzip',
+    async outputDir => {
+      await assertASARDebExists(outputDir)
+
+      const output = await spawn('file', [path.join(outputDir, 'footest_i386.deb')])
+      chai.expect(output).to.contain('compression gz')
+    }
+  )
+
+  describeInstallerWithException(
+    'with wrong compression type',
+    {
+      src: 'test/fixtures/app-with-asar/',
+      options: {
+        compression: 'invalid'
+      }
+    },
+    /^Invalid compression type. xz, gzip, bzip2, lzma, zstd, or none are supported.$/
+  )
 })


### PR DESCRIPTION
Resolves https://github.com/electron-userland/electron-installer-debian/issues/272

This PR combines two fixes from @fcastilloec and @danielferro69 that were submitted and have been open for some time, and allows passing in a compression option. If no option is provided, the packager will use the default value of dpkg-deb installed on the runner.