### PR TITLE
feat!: drop fakeroot, xz compression, update package defaults for modern distros

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,9 +8,15 @@
 
 * Node < 22 support
 * `fs-extra`, `lodash`, and `get-folder-size` dependencies, in favor of Node builtins
+* `fakeroot` requirement: packages are now built with `dpkg-deb --root-owner-group`
 
 ### Changed
 
+* Default compression is now explicitly `xz`, regardless of the host's `dpkg-deb` default
+* Default package dependencies updated for modern distributions: `libsecret-1-0` added to
+  `Depends`, `gnome-keyring` replaces the obsolete GNOME keyring packages in `Suggests`, and
+  `gvfs` replaces the removed `gvfs-bin`
+* Generated desktop entries now include `Terminal=false` and `StartupWMClass`
 * The package is now an ES module: use `import` instead of `require` (CommonJS consumers on
   Node.js >= 22.12 can use `require('electron-installer-debian').default`)
 * Switched package management to Yarn 4

--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@
 
 ## Requirements
 
-This tool requires Node 22.12 or greater, `fakeroot`, and `dpkg` to build the `.deb` package.
+This tool requires Node 22.12 or greater and `dpkg` 1.19.0 or newer to build the `.deb` package.
 
 I'd recommend building your packages on your target platform, but if you insist on using Mac OS X, you can install these tools through [Homebrew](http://brew.sh/):
 
 ```
-$ brew install fakeroot dpkg
+$ brew install dpkg
 ```
 
 
@@ -310,7 +310,7 @@ Estimate of the total amount of disk space required to install the named package
 
 #### options.depends, recommends, suggests, enhances, preDepends
 Type: `Array[String]`
-Default: For `depends`, the minimum set of packages necessary for Electron to run; See [source code](https://github.com/electron-userland/electron-installer-debian/blob/53fb5c5/src/installer.js#L146-L157) for `recommends`, `suggests`, `enhances`, and `preDepends` default values
+Default: For `depends`, the minimum set of packages necessary for Electron to run; See [`src/dependencies.js`](https://github.com/electron-userland/electron-installer-debian/blob/main/src/dependencies.js) for `recommends`, `suggests`, `enhances`, and `preDepends` default values
 
 Relationships to other packages, used in the [`Depends`, `Recommends`, `Suggests`, `Enhances` and `Pre-Depends` fields of the `control` specification](https://www.debian.org/doc/debian-policy/#binary-dependencies-depends-recommends-suggests-enhances-pre-depends).
 

--- a/ci/install-os-dependencies.sh
+++ b/ci/install-os-dependencies.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 case "$(uname -s)" in
   Darwin)
-    brew install dpkg fakeroot
+    brew install dpkg
     ;;
   Linux)
     sudo apt-get --quiet update

--- a/resources/desktop.ejs
+++ b/resources/desktop.ejs
@@ -1,10 +1,12 @@
 [Desktop Entry]
 <% if (productName) { %>Name=<%= productName %>
+StartupWMClass=<%= productName %>
 <% } %><% if (description) { %>Comment=<%= description %>
 <% } %><% if (genericName) { %>GenericName=<%= genericName %>
 <% } %><% if (name) { %>Exec=<%= name %> %U
 Icon=<%= name %>
 <% } %>Type=Application
+Terminal=false
 StartupNotify=true
 <% if (categories && categories.length) { %>Categories=<%= categories.join(';') %>;
 <% } %><% if (mimeType && mimeType.length) { %>MimeType=<%= mimeType.join(';') %>;

--- a/src/dependencies.js
+++ b/src/dependencies.js
@@ -8,7 +8,7 @@ const dependencyMap = {
   glib2: 'libglib2.0-bin',
   gtk2: 'libgtk2.0-0',
   gtk3: 'libgtk-3-0',
-  gvfs: 'gvfs-bin',
+  gvfs: 'gvfs',
   kdeCliTools: 'kde-cli-tools',
   kdeRuntime: 'kde-runtime',
   notify: 'libnotify4',
@@ -35,13 +35,13 @@ export default {
   forElectron: function dependenciesForElectron (electronVersion) {
     return {
       depends: common.getDepends(electronVersion, dependencyMap)
+        .concat(['libsecret-1-0'])
         .concat(trashRequiresAsBoolean(electronVersion, dependencyMap)),
       recommends: [
-        'pulseaudio | libasound2'
+        'libasound2t64 | libasound2 | pulseaudio'
       ],
       suggests: [
-        'gir1.2-gnomekeyring-1.0',
-        'libgnome-keyring0',
+        'gnome-keyring',
         'lsb-release'
       ],
       enhances: [

--- a/src/installer.js
+++ b/src/installer.js
@@ -129,23 +129,17 @@ class DebianInstaller extends common.ElectronInstaller {
   }
 
   /**
-   * Package everything using `dpkg` and `fakeroot`.
+   * Package everything using `dpkg-deb`.
    */
   async createPackage () {
     this.options.logger(`Creating package at ${this.stagingDir}`)
 
-    const command = ['--build', this.stagingDir]
-    if (process.platform === 'darwin') {
-      command.unshift('--root-owner-group')
-    }
-
+    const command = ['--root-owner-group', '--build', this.stagingDir]
     if (this.options.compression) {
       command.unshift(`-Z${this.options.compression}`)
     }
 
-    command.unshift('dpkg-deb')
-
-    const output = await spawn('fakeroot', command, this.options.logger)
+    const output = await spawn('dpkg-deb', command, this.options.logger)
     this.options.logger(`dpkg-deb output: ${output}`)
   }
 
@@ -165,6 +159,7 @@ class DebianInstaller extends common.ElectronInstaller {
 
       section: 'utils',
       priority: 'optional',
+      compression: 'xz',
       size: Math.ceil((size || 0) / 1024),
 
       maintainer: this.getMaintainer(pkg.author),

--- a/src/spawn.js
+++ b/src/spawn.js
@@ -1,16 +1,10 @@
 import { spawn as crossSpawn } from '@malept/cross-spawn-promise'
 
 function updateExecutableMissingException (err, hasLogger) {
-  if (hasLogger && err.code === 'ENOENT') {
-    const isFakeroot = err.syscall === 'spawn fakeroot'
-    const isDpkg = !isFakeroot && err.syscall === 'spawn dpkg'
+  if (hasLogger && err.code === 'ENOENT' && err.syscall === 'spawn dpkg-deb') {
+    const installer = process.platform === 'darwin' ? 'brew' : 'apt-get'
 
-    if (isFakeroot || isDpkg) {
-      const installer = process.platform === 'darwin' ? 'brew' : 'apt-get'
-      const pkg = isFakeroot ? 'fakeroot' : 'dpkg'
-
-      err.message = `Your system is missing the ${pkg} package. Try, e.g. '${installer} install ${pkg}'`
-    }
+    err.message = `Your system is missing the dpkg package. Try, e.g. '${installer} install dpkg'`
   }
 }
 

--- a/test/installer.js
+++ b/test/installer.js
@@ -30,8 +30,13 @@ describe('module', () => {
         categories: []
       }
     },
-    'generates a .deb package',
-    assertASARDebExists
+    'generates a .deb package compressed with xz by default',
+    async outputDir => {
+      await assertASARDebExists(outputDir)
+
+      const output = await spawn('file', [path.join(outputDir, 'footest_i386.deb')])
+      expect(output).to.contain('compression xz')
+    }
   )
 
   describeInstaller(

--- a/test/spawn.js
+++ b/test/spawn.js
@@ -11,12 +11,12 @@ describe('spawn', () => {
     process.env.PATH = '/non-existent-path'
   })
 
-  it('should throw a human-friendly error when it cannot find dpkg or fakeroot', async () => {
+  it('should throw a human-friendly error when it cannot find dpkg-deb', async () => {
     try {
-      await spawn('dpkg', ['--version'], () => {})
-      throw new Error('dpkg should not have been executed')
+      await spawn('dpkg-deb', ['--version'], () => {})
+      throw new Error('dpkg-deb should not have been executed')
     } catch (error) {
-      expect(error.message).to.match(/Error executing command \(dpkg --version\):\nYour system is missing the dpkg package/)
+      expect(error.message).to.match(/Error executing command \(dpkg-deb --version\):\nYour system is missing the dpkg package/)
     }
   })
 


### PR DESCRIPTION
BREAKING CHANGE: Packages are built with `dpkg-deb --root-owner-group` instead of fakeroot, which requires dpkg 1.19.0 or newer. The default compression is now always xz, and the default package dependencies have been updated for modern distributions.