### PR TITLE
docs: replace CI badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Electron Installer for Debian](resources/logo.png)
 
-# electron-installer-debian [![Version](https://img.shields.io/npm/v/electron-installer-debian.svg)](https://www.npmjs.com/package/electron-installer-debian) [![Build Status](https://img.shields.io/travis/electron-userland/electron-installer-debian.svg)](http://travis-ci.org/electron-userland/electron-installer-debian)
+# electron-installer-debian [![Version](https://img.shields.io/npm/v/electron-installer-debian.svg)](https://www.npmjs.com/package/electron-installer-debian) [![CI](https://github.com/electron-userland/electron-installer-debian/actions/workflows/ci.yml/badge.svg)](https://github.com/electron-userland/electron-installer-debian/actions/workflows/ci.yml)
 
 > Create a Debian package for your Electron app.
 


### PR DESCRIPTION
Since we're no longer using Travis CI.